### PR TITLE
Improve UI flexibility

### DIFF
--- a/frontend/shift-view.jsx
+++ b/frontend/shift-view.jsx
@@ -193,10 +193,16 @@ export default function ShiftView({shift, producers, consumers, producerDisplay,
         );
     }).filter((row) => !!row);
 
-    let content;
+    // The container's CSS `height` must be explicitly set only in cases where
+    // overflow is expected. `max-height` is not appropriate for this situation
+    // because it will cause the vertical scroll bar to be assigned to the
+    // container itself (as opposed to the child which exceeds the boundary).
+    let height, content;
     if (consumerRows.length === 0) {
+        height = 'auto';
         content = <p>No consumers found for this period.</p>;
     } else {
+        height = '90%';
         content = (
             <div style={{height: '100%', overflowY: 'auto'}}>
                 <Box style={{
@@ -252,7 +258,7 @@ export default function ShiftView({shift, producers, consumers, producerDisplay,
 
     return (
         <DndProvider backend={Backend}>
-            <Box style={{height: '90%', display: 'flex', flexDirection: 'column'}}>
+            <Box style={{height, display: 'flex', flexDirection: 'column'}}>
                 <header className="clearfix">
                     <Heading as="h3" style={{float: 'left'}}>
                         {shift.day} {shift.timeOfDay}

--- a/frontend/shift-view.jsx
+++ b/frontend/shift-view.jsx
@@ -191,62 +191,72 @@ export default function ShiftView({shift, producers, consumers, producerStat, on
 	if (consumerRows.length === 0) {
 		content = <p>No consumers found for this period.</p>;
 	} else {
-		content = <>
-			<Box style={{
-				position: 'absolute',
-				top: 0,
-				bottom: 0,
-				left: 0,
-				width: '20%',
-				overflowY: 'auto'
-			}}>
-				<AssignmentDropTarget
-					consumerId={null}
-					accept={id}
-					onAssign={assign}
-				>
-					<Heading as="h4" style={{fontSize: '1em'}}>
-						unassigned
-					</Heading>
-
-					<AssignmentList
+		content = (
+			<div style={{height: '100%', overflowY: 'auto'}}>
+				<Box style={{
+					position: 'absolute',
+					top: 0,
+					bottom: 0,
+					left: 0,
+					width: '20%',
+					overflowY: 'auto'
+				}}>
+					<AssignmentDropTarget
 						consumerId={null}
-						producers={producers}
-						assignments={nullAssignments}
-						stat={producerStat}
-						type={id}
-						/>
-				</AssignmentDropTarget>
-			</Box>
+						accept={id}
+						onAssign={assign}
+					>
+						<Heading as="h4" style={{fontSize: '1em'}}>
+							unassigned
+						</Heading>
 
-			<table
-				cellSpacing="0"
-				style={{marginLeft: '20%', width: '80%', paddingLeft: '1em'}}>
-				<thead>
-					<tr>
-						<td>Name</td>
-						<td>Time</td>
-						<td colSpan="3" style={{textAlign: 'center'}}>
-							Fulfillment
-						</td>
-					</tr>
-				</thead>
-				{consumerRows}
-			</table>
-		</>;
+						<AssignmentList
+							consumerId={null}
+							producers={producers}
+							assignments={nullAssignments}
+							stat={producerStat}
+							type={id}
+							/>
+					</AssignmentDropTarget>
+				</Box>
+
+				<table
+					cellSpacing="0"
+					style={{
+						marginLeft: '20%',
+						width: '80%',
+						paddingLeft: '1em',
+						height: '100%',
+						overflowY: 'auto'
+					}}>
+					<thead>
+						<tr>
+							<td>Name</td>
+							<td>Time</td>
+							<td colSpan="3" style={{textAlign: 'center'}}>
+								Fulfillment
+							</td>
+						</tr>
+					</thead>
+					{consumerRows}
+				</table>
+			</div>
+		);
 	}
 
 	return (
 		<DndProvider backend={Backend}>
-			<header className="clearfix">
-				<Heading as="h3" style={{float: 'left'}}>
-					{shift.day} {shift.timeOfDay}
-				</Heading>
-				<span style={{float: 'right'}}>{shift.date}</span>
-			</header>
+			<Box style={{height: '90%', display: 'flex', flexDirection: 'column'}}>
+				<header className="clearfix">
+					<Heading as="h3" style={{float: 'left'}}>
+						{shift.day} {shift.timeOfDay}
+					</Heading>
+					<span style={{float: 'right'}}>{shift.date}</span>
+				</header>
 
-			<Box marginBottom={4} style={{position: 'relative'}}>
-				{content}
+				<Box marginBottom={4} style={{flexGrow: 1, position: 'relative', overflowY: 'auto'}}>
+					{content}
+				</Box>
 			</Box>
 		</DndProvider>
 	);

--- a/frontend/shift-view.jsx
+++ b/frontend/shift-view.jsx
@@ -238,7 +238,7 @@ export default function ShiftView({shift, producers, consumers, producerDisplay,
                         marginLeft: '20%',
                         width: '80%',
                         paddingLeft: '1em',
-                        height: '100%',
+                        maxHeight: '100%',
                         overflowY: 'auto'
                     }}>
                     <thead>


### PR DESCRIPTION
For any given shift, ensure that every restaurant can be viewed
alongside any hospital.

Previously, the hospital list dictated the height of each shift. This
accommodated assignment in cases where there were more restaurants than
hospitals as in the following wireframe:

    .----------------------------------------------------. |^|
    | (shift title)                                      | | |
    | .----------------------.                           | | |
    | |                    |^|                           | | |
    | | (restaurants)      | |    (hospitals)            | | |
    | |                    |v|                           | | |
    | '----------------------'                           | | |
    '----------------------------------------------------' | |
    .----------------------------------------------------. | |
    | (shift title)                                      | |v|
    ----------------------------------------------------------
      (tools)                            (budget)

However, when there were more hospitals than restaraunts, every
restaurant could not necessarily be viewed alongside every hospital:

    | | (final restaurant)   |                           | |^|
    | '----------------------'                           | | |
    |                                                    | | |
    |                                                    | | |
    |                           (final hospital)         | | |
    '----------------------------------------------------' | |
    .----------------------------------------------------. | |
    | (shift title)                                      | |v|
    ----------------------------------------------------------
      (tools)                            (budget)

In a drag-and-drop interface such as this, it is critical for every
draggable element (restaurants) to be visible alongside every drop
target (hospital).

Alter the layout such that every shift is always completely visible and
that both the list of restaurants and the list of hospitals is presented
with a scroll bar whenever their contents exceed the available vertical
space:

    .----------------------------------------------------. |^|
    | (shift title)                                      | | |
    | .----------------------.  .----------------------. | | |
    | |                    |^|  |                    |^| | | |
    | | (restaurants)      | |  | (hospitals)        | | | | |
    | |                    |v|  |                    |v| | | |
    | '----------------------'  '----------------------' | | |
    '----------------------------------------------------' | |
    .----------------------------------------------------. | |
    | (shift title)                                      | |v|
    ----------------------------------------------------------
      (tools)                            (budget)