### PR TITLE
Optionally display descriptor next to producer

### DIFF
--- a/frontend/chooser.jsx
+++ b/frontend/chooser.jsx
@@ -38,10 +38,11 @@ const sortOptions = [
 	{value: 'price', label: 'Price'}
 ];
 
-const producerStats = [
+const producerDisplayOptions = [
 	{value: null, label: 'none'},
 	{value: 'capacity', label: 'Capacity'},
-	{value: 'price', label: 'Price'}
+	{value: 'price', label: 'Price'},
+	{value: 'descriptor', label: 'Descriptor'}
 ];
 
 export default function Chooser({producers, consumers, assignments, onAssign}) {
@@ -50,7 +51,7 @@ export default function Chooser({producers, consumers, assignments, onAssign}) {
 	producers = annotateExtremes(producers, 'price');
 
 	const [sort, setSort] = useState('name');
-	const [producerStat, setProducerStat] = useState(null);
+	const [producerDisplay, setProducerDisplay] = useState(null);
 	const [budget, setBudget] = useState(10 * 1000);
 	const [startDate, setStartDate] = useState(
 		() => moment().set('day', 0).startOf('day').utc().startOf('day').add(1, 'week').format()
@@ -93,7 +94,7 @@ export default function Chooser({producers, consumers, assignments, onAssign}) {
 						shift={shift}
 						consumers={consumers}
 						producers={producers}
-						producerStat={producerStat}
+						producerDisplay={producerDisplay}
 						onAssign={onAssign} />
 				))}
 			</Box>
@@ -106,8 +107,8 @@ export default function Chooser({producers, consumers, assignments, onAssign}) {
 				</Box>
 
 				<Box paddingRight={3}>
-					<FormField label="Producer statistic">
-						<Select options={producerStats} value={producerStat} onChange={setProducerStat} />
+					<FormField label="Producer display">
+						<Select options={producerDisplayOptions} value={producerDisplay} onChange={setProducerDisplay} />
 					</FormField>
 				</Box>
 

--- a/frontend/index.jsx
+++ b/frontend/index.jsx
@@ -112,6 +112,7 @@ function CapacityPlanner() {
 		capacity: globalConfig.get('producers:capacity'),
 		price: globalConfig.get('producers:price'),
 		times: globalConfig.get('producers:times'),
+		descriptor: globalConfig.get('producers:descriptor'),
 	};
 
 	useSettingsButton(() => setIsShowingSettings(!isShowingSettings));
@@ -187,6 +188,7 @@ function CapacityPlanner() {
 		name: record.name,
 		capacity: record.getCellValue(producerFields.capacity),
 		price: record.getCellValue(producerFields.price),
+                descriptor: record.getCellValue(producerFields.descriptor),
 		// "Shifts" is a linked record. Although `selectLinkedRecordsFromCell`
 		// is technically more appropriate, it can't be used in a synchronous
 		// context. Instead, operate on each record's name (which is available

--- a/frontend/settings.jsx
+++ b/frontend/settings.jsx
@@ -204,6 +204,16 @@ export default function Settings({consumerName, producerName, assignmentName}) {
 					/>
 				</FormField>
 
+				<FormField
+					label={'Field for "Descriptor"'}
+					style={fieldStyle}>
+					<FieldPickerSynced
+						globalConfigKey="producers:descriptor"
+						allowedTypes={[FieldType.SINGLE_LINE_TEXT]}
+						table={producersTable}
+					/>
+				</FormField>
+
 				<h3>
 					{producerIds ? producerIds.length : 0} {producerName} selected
 				</h3>

--- a/frontend/shift-view.jsx
+++ b/frontend/shift-view.jsx
@@ -29,7 +29,7 @@ function AssignmentDropTarget({as, children, consumerId, onAssign, accept, ...re
 	);
 }
 
-function AssignmentList({consumerId, style, producers, assignments, stat, type}) {
+function AssignmentList({consumerId, style, producers, assignments, display, type}) {
 	const items = assignments
 		.filter((assignment) => assignment.consumerId === consumerId)
 		.map((assignment) => (
@@ -38,7 +38,7 @@ function AssignmentList({consumerId, style, producers, assignments, stat, type})
 				assignment={assignment}
 				producer={producers.find(({id}) => id === assignment.producerId)}
 				type={type}
-				stat={stat} />));
+				display={display} />));
 
 	return (
 		<ul style={{listStyleType: 'none', margin: 0, padding: 0, ...style}}>
@@ -47,7 +47,7 @@ function AssignmentList({consumerId, style, producers, assignments, stat, type})
 	);
 }
 
-function AssignmentItem({producer, assignment, type, stat}) {
+function AssignmentItem({producer, assignment, type, display}) {
 	const [, drag] = useDrag({
 		item: { id: assignment.id, type }
 	});
@@ -65,20 +65,26 @@ function AssignmentItem({producer, assignment, type, stat}) {
 				backgroundColor: '#fff'
 			}}
 			>
-			<span style={{float: 'left'}}>{producer.name} ({assignment.amount}/{producer.capacity})</span>
-			{stat ?
+			<span style={{float: 'left'}}>
+                          {producer.name} ({assignment.amount}/{producer.capacity})
+                          {display == 'descriptor' ? <span style={{color: 'gray', marginLeft: '0.5em'}}>{producer.descriptor}</span> : '' }
+                        </span>
+
+
+			{display == 'price' || display == 'capacity' ?
 				<Rating
 					style={{float: 'right', marginLeft: '1em'}}
-					value={producer[stat]}
-					min={producer[`min${stat}`]}
-					max={producer[`max${stat}`]} />
+					value={producer[display]}
+					min={producer[`min${display}`]}
+					max={producer[`max${display}`]} />
 				: ''}
+
 		</li>
 	);
 }
 
 function ConsumerRow({
-	consumer, time, producers, assignments, onAssign, accept, producerStat
+	consumer, time, producers, assignments, onAssign, accept, producerDisplay
 }) {
 	const provided = assignments.reduce((total, assignment) => {
 		return total + assignment.amount;
@@ -137,7 +143,7 @@ function ConsumerRow({
 						consumerId={consumer.id}
 						producers={producers}
 						assignments={assignments}
-						stat={producerStat}
+						display={producerDisplay}
 						type={accept}
 					/>
 				</td>
@@ -147,7 +153,7 @@ function ConsumerRow({
 	);
 }
 
-export default function ShiftView({shift, producers, consumers, producerStat, onAssign}) {
+export default function ShiftView({shift, producers, consumers, producerDisplay, onAssign}) {
 	const id = `${shift.date} ${shift.timeOfDay}`;
 	const nullAssignments = buildNullAssignments(
 		shift.date, shift.timeOfDay, producers, shift.assignments
@@ -183,7 +189,7 @@ export default function ShiftView({shift, producers, consumers, producerStat, on
 				assignments={shift.assignments.filter(({consumerId}) => consumerId === consumer.id)}
 				accept={id}
 				onAssign={assign}
-				producerStat={producerStat} />
+				producerDisplay={producerDisplay} />
 		);
 	}).filter((row) => !!row);
 
@@ -213,7 +219,7 @@ export default function ShiftView({shift, producers, consumers, producerStat, on
 						consumerId={null}
 						producers={producers}
 						assignments={nullAssignments}
-						stat={producerStat}
+						display={producerDisplay}
 						type={id}
 						/>
 				</AssignmentDropTarget>


### PR DESCRIPTION
Addresses issue: https://github.com/bocoup/blocks-capacity-planner/issues/4

- Add an additional "descriptor" selection to the producer settings
- Using "descriptor" instead of "cuisine" so in the setting any text
description for a producer could be shown, though the feature was
initially requested to show the cuisine
- Change the producer statistics dropdown to be a producer display
dropdown. Add "descriptor" as one of the options.
- When the "descriptor" is chosen as a display option display inline on
the `AssignmentItem`

This is what it looks like on the with the example base:
![screencapture-airtable-tblHX4DpFA6Nq2um5-viw8peZ3bRFpYOBbC-2020-05-04-14_34_00](https://user-images.githubusercontent.com/352375/81016615-a44a1f80-8e15-11ea-91fa-d8357b058ad3.png)
