### PR TITLE
Rework build shifts to be meals

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ visualize, manipulate and process data from that base.
 - **producer** - an entity described by: "name" (a string value), "capacity"
   (an integer value), "price" (a floating point number), and "times" (one or
   more day-of-week/time-of-day pairs)
-- **shift** - a day of the week and a time of day, e.g. "Tuesday afternoon"
+- **shift** - a day of the week and a meal time, e.g. "Tuesday lunch"
 
 This block was initially developed for use by volunteer organizers during the
 covid-19 pandemic to plan weekly schedules for meal deliveries from restaurants

--- a/frontend/build-shifts.js
+++ b/frontend/build-shifts.js
@@ -12,7 +12,7 @@ export default function buildShifts({startDate, endDate, assignments}) {
     }
 
     while (!current.isSame(end, 'day')) {
-        for (const timeOfDay of ['afternoon', 'evening']) {
+        for (const timeOfDay of ['breakfast', 'lunch', 'dinner', 'late night']) {
             shifts.push({
                 date: current.format('YYYY-MM-DD'),
                 day: current.format('dddd'),

--- a/frontend/is-time-of-day.js
+++ b/frontend/is-time-of-day.js
@@ -1,4 +1,13 @@
 export default function isTimeOfDay (time, timeOfDay) {
     const hour = parseInt(time.split(':')[0], 10);
-    return (hour < 16) !== (timeOfDay === 'evening');
+    switch(timeOfDay) {
+    case 'breakfast':
+        return hour >= 5 && hour < 11;
+    case 'lunch':
+        return hour >= 11 && hour < 16;
+    case 'dinner':
+        return hour >= 16 && hour < 21;
+    case 'late night':
+        return (hour >= 0 && hour < 5) || hour >=21;
+    }
 }

--- a/test/build-shifts.js
+++ b/test/build-shifts.js
@@ -3,63 +3,87 @@ import assert from 'assert';
 import buildShifts from '../frontend/build-shifts.js';
 
 suite('buildShifts', () => {
-	test('time values', () => {
-		const shifts = buildShifts({
-			startDate: '2020-04-23', endDate: '2020-04-26', assignments: []
-		});
+    test('time values', () => {
+        const shifts = buildShifts({
+            startDate: '2020-04-23', endDate: '2020-04-26', assignments: []
+        });
 
-		assert(Array.isArray(shifts));
-		assert.equal(shifts.length, 6);
-		assert.deepEqual(
-			[shifts[0].date, shifts[0].day, shifts[0].timeOfDay],
-			['2020-04-23', 'Thursday', 'afternoon']
-		);
-		assert.deepEqual(
-			[shifts[1].date, shifts[1].day, shifts[1].timeOfDay],
-			['2020-04-23', 'Thursday', 'evening']
-		);
-		assert.deepEqual(
-			[shifts[2].date, shifts[2].day, shifts[2].timeOfDay],
-			['2020-04-24', 'Friday', 'afternoon']
-		);
-		assert.deepEqual(
-			[shifts[3].date, shifts[3].day, shifts[3].timeOfDay],
-			['2020-04-24', 'Friday', 'evening']
-		);
-		assert.deepEqual(
-			[shifts[4].date, shifts[4].day, shifts[4].timeOfDay],
-			['2020-04-25', 'Saturday', 'afternoon']
-		);
-		assert.deepEqual(
-			[shifts[5].date, shifts[5].day, shifts[5].timeOfDay],
-			['2020-04-25', 'Saturday', 'evening']
-		);
-	});
+        assert(Array.isArray(shifts));
+        assert.equal(shifts.length, 12);
+        assert.deepEqual(
+            [shifts[0].date, shifts[0].day, shifts[0].timeOfDay],
+            ['2020-04-23', 'Thursday', 'breakfast']
+        );
+        assert.deepEqual(
+            [shifts[1].date, shifts[1].day, shifts[1].timeOfDay],
+            ['2020-04-23', 'Thursday', 'lunch']
+        );
+        assert.deepEqual(
+            [shifts[2].date, shifts[2].day, shifts[2].timeOfDay],
+            ['2020-04-23', 'Thursday', 'dinner']
+        );
+        assert.deepEqual(
+            [shifts[3].date, shifts[3].day, shifts[3].timeOfDay],
+            ['2020-04-23', 'Thursday', 'late night']
+        );
+        assert.deepEqual(
+            [shifts[4].date, shifts[4].day, shifts[4].timeOfDay],
+            ['2020-04-24', 'Friday', 'breakfast']
+        );
+        assert.deepEqual(
+            [shifts[5].date, shifts[5].day, shifts[5].timeOfDay],
+            ['2020-04-24', 'Friday', 'lunch']
+        );
+        assert.deepEqual(
+            [shifts[6].date, shifts[6].day, shifts[6].timeOfDay],
+            ['2020-04-24', 'Friday', 'dinner']
+        );
+        assert.deepEqual(
+            [shifts[7].date, shifts[7].day, shifts[7].timeOfDay],
+            ['2020-04-24', 'Friday', 'late night']
+        );
+        assert.deepEqual(
+            [shifts[8].date, shifts[8].day, shifts[8].timeOfDay],
+            ['2020-04-25', 'Saturday', 'breakfast']
+        );
+        assert.deepEqual(
+            [shifts[9].date, shifts[9].day, shifts[9].timeOfDay],
+            ['2020-04-25', 'Saturday', 'lunch']
+        );
+        assert.deepEqual(
+            [shifts[10].date, shifts[10].day, shifts[10].timeOfDay],
+            ['2020-04-25', 'Saturday', 'dinner']
+        );
+        assert.deepEqual(
+            [shifts[11].date, shifts[11].day, shifts[11].timeOfDay],
+            ['2020-04-25', 'Saturday', 'late night']
+        );
+    });
 
-	test('invalid start date', () => {
-		const shifts = buildShifts({
-			startDate: '2020-02-30', endDate: '2020-04-26', assignments: []
-		});
+    test('invalid start date', () => {
+        const shifts = buildShifts({
+            startDate: '2020-02-30', endDate: '2020-04-26', assignments: []
+        });
 
-		assert(Array.isArray(shifts));
-		assert.equal(shifts.length, 0);
-	});
+        assert(Array.isArray(shifts));
+        assert.equal(shifts.length, 0);
+    });
 
-	test('invalid end date', () => {
-		const shifts = buildShifts({
-			startDate: '2020-04-23', endDate: '2020-04-31', assignments: []
-		});
+    test('invalid end date', () => {
+        const shifts = buildShifts({
+            startDate: '2020-04-23', endDate: '2020-04-31', assignments: []
+        });
 
-		assert(Array.isArray(shifts));
-		assert.equal(shifts.length, 0);
-	});
+        assert(Array.isArray(shifts));
+        assert.equal(shifts.length, 0);
+    });
 
-	test('end date preceded start date', () => {
-		const shifts = buildShifts({
-			startDate: '2020-04-26', endDate: '2020-04-23', assignments: []
-		});
+    test('end date preceded start date', () => {
+        const shifts = buildShifts({
+            startDate: '2020-04-26', endDate: '2020-04-23', assignments: []
+        });
 
-		assert(Array.isArray(shifts));
-		assert.equal(shifts.length, 0);
-	});
+        assert(Array.isArray(shifts));
+        assert.equal(shifts.length, 0);
+    });
 });

--- a/test/is-time-of-day.js
+++ b/test/is-time-of-day.js
@@ -3,45 +3,134 @@ import assert from 'assert';
 import isTimeOfDay from '../frontend/is-time-of-day.js';
 
 suite('isTimeOfDay', () => {
-	suite('positive', () => {
-		test('00:00', () => {
-			assert(isTimeOfDay('00:00', 'afternoon'));
-		});
-		test('12:00', () => {
-			assert(isTimeOfDay('12:00', 'afternoon'));
-		});
-		test('12:01', () => {
-			assert(isTimeOfDay('12:01', 'afternoon'));
-		});
-		test('15:59', () => {
-			assert(isTimeOfDay('15:59', 'afternoon'));
-		});
-		test('16:00', () => {
-			assert(isTimeOfDay('16:00', 'evening'));
-		});
-		test('23:59', () => {
-			assert(isTimeOfDay('23:59', 'evening'));
-		});
-	});
+    suite('positive', () => {
+        test('00:00', () => {
+            assert(isTimeOfDay('00:00', 'late night'));
+        });
+        test('04:59', () => {
+            assert(isTimeOfDay('04:49', 'late night'));
+        });
+        test('05:00', () => {
+            assert(isTimeOfDay('05:00', 'breakfast'));
+        });
+        test('10:59', () => {
+            assert(isTimeOfDay('10:59', 'breakfast'));
+        });
+        test('11:00', () => {
+            assert(isTimeOfDay('11:00', 'lunch'));
+        });
+        test('15:59', () => {
+            assert(isTimeOfDay('15:59', 'lunch'));
+        });
+        test('16:00', () => {
+            assert(isTimeOfDay('16:00', 'dinner'));
+        });
+        test('20:59', () => {
+            assert(isTimeOfDay('20:59', 'dinner'));
+        });
+        test('21:00', () => {
+            assert(isTimeOfDay('21:00', 'late night'));
+        });
+        test('23:59', () => {
+            assert(isTimeOfDay('23:59', 'late night'));
+        });
+    });
 
-	suite('negative', () => {
-		test('00:00', () => {
-			assert.equal(isTimeOfDay('00:00', 'evening'), false);
-		});
-		test('12:00', () => {
-			assert.equal(isTimeOfDay('12:00', 'evening'), false);
-		});
-		test('12:01', () => {
-			assert.equal(isTimeOfDay('12:01', 'evening'), false);
-		});
-		test('15:59', () => {
-			assert.equal(isTimeOfDay('15:59', 'evening'), false);
-		});
-		test('16:00', () => {
-			assert.equal(isTimeOfDay('16:00', 'afternoon'), false);
-		});
-		test('23:59', () => {
-			assert.equal(isTimeOfDay('23:59', 'afternoon'), false);
-		});
-	});
+    suite('negative', () => {
+        // Late night
+        test('00:00', () => {
+            assert.equal(isTimeOfDay('00:00', 'breakfast'), false);
+        });
+        test('00:00', () => {
+            assert.equal(isTimeOfDay('00:00', 'lunch'), false);
+        });
+        test('00:00', () => {
+            assert.equal(isTimeOfDay('00:00', 'dinner'), false);
+        });
+        test('04:59', () => {
+            assert.equal(isTimeOfDay('04:49', 'breakfast'), false);
+        });
+        test('04:59', () => {
+            assert.equal(isTimeOfDay('04:49', 'lunch'), false);
+        });
+        test('04:59', () => {
+            assert.equal(isTimeOfDay('04:49', 'dinner'), false);
+        });
+        // Breakfast
+        test('05:00', () => {
+            assert.equal(isTimeOfDay('05:00', 'lunch'), false);
+        });
+        test('05:00', () => {
+            assert.equal(isTimeOfDay('05:00', 'dinner'), false);
+        });
+        test('05:00', () => {
+            assert.equal(isTimeOfDay('05:00', 'late night'), false);
+        });
+        test('10:59', () => {
+            assert.equal(isTimeOfDay('10:59', 'lunch'), false);
+        });
+        test('10:59', () => {
+            assert.equal(isTimeOfDay('10:59', 'dinner'), false);
+        });
+        test('10:59', () => {
+            assert.equal(isTimeOfDay('10:59', 'late night'), false);
+        });
+        // Lunch
+        test('11:00', () => {
+            assert.equal(isTimeOfDay('11:00', 'breakfast'), false);
+        });
+        test('11:00', () => {
+            assert.equal(isTimeOfDay('11:00', 'dinner'), false);
+        });
+        test('11:00', () => {
+            assert.equal(isTimeOfDay('11:00', 'late night'), false);
+        });
+        test('15:59', () => {
+            assert.equal(isTimeOfDay('15:59', 'breakfast'), false);
+        });
+        test('15:59', () => {
+            assert.equal(isTimeOfDay('15:59', 'dinner'), false);
+        });
+        test('15:59', () => {
+            assert.equal(isTimeOfDay('15:59', 'late night'), false);
+        });
+        // Dinner
+        test('16:00', () => {
+            assert.equal(isTimeOfDay('16:00', 'breakfast'), false);
+        });
+        test('16:00', () => {
+            assert.equal(isTimeOfDay('16:00', 'lunch'), false);
+        });
+        test('16:00', () => {
+            assert.equal(isTimeOfDay('16:00', 'late night'), false);
+        });
+        test('20:59', () => {
+            assert.equal(isTimeOfDay('20:59', 'breakfast'), false);
+        });
+        test('20:59', () => {
+            assert.equal(isTimeOfDay('20:59', 'lunch'), false);
+        });
+        test('20:59', () => {
+            assert.equal(isTimeOfDay('20:59', 'late night'), false);
+        });
+        // Late night
+        test('21:00', () => {
+            assert.equal(isTimeOfDay('21:00', 'breakfast'), false);
+        });
+        test('21:00', () => {
+            assert.equal(isTimeOfDay('21:00', 'lunch'), false);
+        });
+        test('21:00', () => {
+            assert.equal(isTimeOfDay('21:00', 'dinner'), false);
+        });
+        test('23:59', () => {
+            assert.equal(isTimeOfDay('23:59', 'breakfast'), false);
+        });
+        test('23:59', () => {
+            assert.equal(isTimeOfDay('23:59', 'lunch'), false);
+        });
+        test('23:59', () => {
+            assert.equal(isTimeOfDay('23:59', 'dinner'), false);
+        });
+    });
 });


### PR DESCRIPTION
Address this issue: https://github.com/bocoup/blocks-capacity-planner/issues/15

- Move from afternoon and evening to breakfast, lunch, dinner, and late-night shifts
- There are now a bunch of empty shifts (at least on the example block) that don't blow up but do create some noise in the UI. I left them for now though.

![screencapture-airtable-tblnz9rumCvnTdN3K-viwYh7lzHleDrGhix-2020-05-12-13_32_18](https://user-images.githubusercontent.com/352375/81742785-7d16d200-9455-11ea-8e02-291ed8f19613.png)
