### PR TITLE
Introduce an editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,jsx,json}]
+charset = utf-8
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
The [editorconfig] file alerts editors to the desired indentation
conventions for the project. [Plugins] exist for many editors.

[editorconfig]: https://editorconfig.org/
[Plugins]: https://editorconfig.org/#download

The goal is to match what we have configured for ESlint: four space
indentation, using spaces not tabs. Additionally we mandate the typical
unix conventions: newline is \n, and the final line ends with a newline.