### PR TITLE
Introduce upgrade guide

### DIFF
--- a/frontend/chooser.jsx
+++ b/frontend/chooser.jsx
@@ -10,6 +10,7 @@ import moment from 'moment';
 
 import buildShifts from './build-shifts';
 import priceAssignments from './price-assignments';
+import UpgradeGuide from './upgrade-guide';
 import Constraints from './constraints';
 import ShiftView from './shift-view';
 
@@ -118,6 +119,7 @@ export default function Chooser({producers, consumers, assignments, onAssign}) {
                 >
 					Schedule constraints
                 </Button>
+                <UpgradeGuide marginRight={3} />
 
                 <Box flexGrow={1} paddingRight={3}>
                     <ProgressBar progress={cost/budget} barColor={barColor} style={{height: '1em'}} />

--- a/frontend/index.jsx
+++ b/frontend/index.jsx
@@ -12,6 +12,7 @@ import React, {useState} from 'react';
 
 import Chooser from './chooser';
 import Settings from './settings';
+import UpgradeGuide from './upgrade-guide';
 
 loadCSSFromString(`
 	.clearfix:after {
@@ -164,6 +165,8 @@ function CapacityPlanner() {
                 <Button onClick={() => setIsShowingSettings(true)}>
 					Open the configuration page
                 </Button>
+
+                <UpgradeGuide displayText={true} />
             </Box>
         );
     }

--- a/frontend/upgrade-guide.jsx
+++ b/frontend/upgrade-guide.jsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import {
+    Button,
+    Dialog,
+    Heading,
+    loadCSSFromString,
+    Tooltip
+} from '@airtable/blocks/ui';
+
+loadCSSFromString(`
+    .upgrade-guide {
+        max-width: 90vw;
+        max-height: 90vh;
+        display: flex;
+
+        flex-direction: column;
+    }
+
+    .upgrade-guide h2 {
+        margin: 0;
+    }
+
+    .upgrade-guide .contents {
+        flex-grow: 1;
+        overflow-y: auto;
+    }
+`);
+
+export default function UpgradeGuide({displayText, ...otherProps}) {
+    const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+    return (
+        <React.Fragment>
+            <Tooltip
+                content="Upgrade guide">
+                <Button
+                    onClick={() => setIsDialogOpen(true)}
+                    icon="book"
+                    aria-label="Upgrade guide"
+                    {...otherProps}
+                >
+                    {displayText ? 'Upgrade guide' : ''}
+                </Button>
+            </Tooltip>
+
+            {isDialogOpen && (
+                <Dialog
+                    onClose={() => setIsDialogOpen(false)}
+                    className="upgrade-guide"
+                >
+                    <header>
+                        <Heading>Upgrade guide</Heading>
+                        <Dialog.CloseButton />
+                    </header>
+                    {contents}
+                </Dialog>
+            )}
+        </React.Fragment>
+    );
+}
+
+/* eslint-disable react/no-unescaped-entities */
+const contents = <div className="contents">
+    <p>
+        Occassionally, using a new release of the Capacity Planner block
+        requires making some change to your base or the block's settings. This
+        guide explains each release and what must be done to support it.
+    </p>
+
+    <h2>Version 1.1</h2>
+    <time>2020-05-18</time>
+    <p>
+        <b>Enhancement:</b> replace "afternoon" and "evening" shifts with
+        "breakfast," "lunch," "dinner," and "late night" shifts.
+    </p>
+
+    <p>
+        <b>To upgrade:</b> change the restaurant "availability" values from
+        (for example) "Sunday evening" to "Sunday dinner".
+    </p>
+
+    <h2>Version 1.0</h2>
+    <time>2020-04-15</time>
+
+    <p>Initial release.</p>
+</div>;


### PR DESCRIPTION
Ideally, we would manage the upgrade guide in a text file and load that into the application. The Airtable Custom Blocks Beta does not support loading non-JavaScript assets at this time, so we'll have to maintain it as code.

This patch demonstrates the expected usage of the feature via some instructions related to gh-37 (which we merged earlier today).

![2020-05-18-upgrade-guide](https://user-images.githubusercontent.com/677252/82276456-5411a800-9953-11ea-9739-4ad728085a93.png)