### PR TITLE
Add minor copy changes to tool body

### DIFF
--- a/frontend/shift-view.jsx
+++ b/frontend/shift-view.jsx
@@ -249,10 +249,10 @@ export default function ShiftView({shift, producers, consumers, producerDisplay,
                     <caption style={{textAlign: 'left', fontWeight: 'bold', paddingLeft: '10px', paddingBottom: '10px'}}>Recipients</caption>
                     <thead>
                         <tr>
-                            <td>Name</td>
-                            <td>Time</td>
-                            <td>Amount</td>
-                            <td colSpan="2" style={{textAlign: 'center'}}>
+                            <td style={{textTransform: 'uppercase' }}>Name</td>
+                            <td style={{textTransform: 'uppercase' }}>Time</td>
+                            <td style={{textTransform: 'uppercase' }}>Amount</td>
+                            <td colSpan="2" style={{textTransform: 'uppercase', textAlign: 'center'}}>
                                 Fulfillment
                             </td>
                         </tr>

--- a/frontend/shift-view.jsx
+++ b/frontend/shift-view.jsx
@@ -252,7 +252,7 @@ export default function ShiftView({shift, producers, consumers, producerDisplay,
                             <td>Name</td>
                             <td>Time</td>
                             <td>Amount</td>
-                            <td colSpan="3" style={{textAlign: 'center'}}>
+                            <td colSpan="2" style={{textAlign: 'center'}}>
                                 Fulfillment
                             </td>
                         </tr>

--- a/frontend/shift-view.jsx
+++ b/frontend/shift-view.jsx
@@ -223,8 +223,8 @@ export default function ShiftView({shift, producers, consumers, producerDisplay,
                         accept={id}
                         onAssign={assign}
                     >
-                        <Heading as="h4" style={{fontSize: '1em'}}>
-                            unassigned
+                        <Heading as="h4" style={{fontSize: '1em', fontWeight: 'bold'}}>
+                            Ready to Deliver Restaurants
                         </Heading>
 
                         <AssignmentList
@@ -246,10 +246,12 @@ export default function ShiftView({shift, producers, consumers, producerDisplay,
                         maxHeight: '100%',
                         overflowY: 'auto'
                     }}>
+                    <caption style={{textAlign: 'left', fontWeight: 'bold', paddingLeft: '10px', paddingBottom: '10px'}}>Recipients</caption>
                     <thead>
                         <tr>
                             <td>Name</td>
                             <td>Time</td>
+                            <td>Amount</td>
                             <td colSpan="3" style={{textAlign: 'center'}}>
                                 Fulfillment
                             </td>


### PR DESCRIPTION
- Rename "unassigned" to "Ready to Deliver Restaurants"
- Add overarching text on the hospitals side "Recipients" (above name, time, fulfillment)
- Add label "Amount" above the amount column

Closes: https://github.com/bocoup/blocks-capacity-planner/issues/40

The other changes requested in the issue are handled in other PRs.

![Screenshot from 2020-05-27 13-50-02](https://user-images.githubusercontent.com/352375/83070964-226aa200-a021-11ea-970c-683f347af31f.png)
